### PR TITLE
Improve math display with proper symbols and vertical fractions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
@@ -303,20 +303,30 @@ private fun SherlockCalculationPreview() {
 
 @Composable
 private fun ChainCalculationPreview() {
-    Text(
-        text = "5 + 3 \u00D7 2",
+    MathText(
+        text = "5 + 3 * 2",
         style = MaterialTheme.typography.headlineSmall,
-        textAlign = TextAlign.Center,
     )
 }
 
 @Composable
 private fun FractionCalculationPreview() {
-    Text(
-        text = "(2/3) \u00D7 (4/5)",
-        style = MaterialTheme.typography.titleLarge,
-        textAlign = TextAlign.Center,
-    )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        FractionText(
+            numerator = "2",
+            denominator = "3",
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Text("\u00D7", style = MaterialTheme.typography.titleLarge)
+        FractionText(
+            numerator = "4",
+            denominator = "5",
+            style = MaterialTheme.typography.titleLarge,
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/MathText.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/MathText.kt
@@ -1,0 +1,80 @@
+package com.inspiredandroid.braincup.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+
+/**
+ * Replace * with × and / with ÷ for better math display.
+ */
+fun String.formatMathSymbols(): String {
+    return this.replace("*", " \u00D7 ")
+        .replace("/", " \u00F7 ")
+        .replace("+", " + ")
+        .replace("-", " - ")
+        .replace("  ", " ")
+        .trim()
+}
+
+@Composable
+fun MathText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+) {
+    Text(
+        text = text.formatMathSymbols(),
+        modifier = modifier,
+        style = style,
+    )
+}
+
+@Composable
+fun FractionText(
+    numerator: String,
+    denominator: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+) {
+    val barColor = if (color != Color.Unspecified) {
+        color
+    } else if (style.color != Color.Unspecified) {
+        style.color
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    Column(
+        modifier = modifier.width(IntrinsicSize.Min),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = numerator,
+            style = style,
+            color = color,
+            maxLines = 1,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(barColor),
+        )
+        Text(
+            text = denominator,
+            style = style,
+            color = color,
+            maxLines = 1,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/screens/GameScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/screens/GameScreen.kt
@@ -27,12 +27,7 @@ import com.inspiredandroid.braincup.games.OrbitTrackerGame
 import com.inspiredandroid.braincup.games.VisualMemoryGame
 import com.inspiredandroid.braincup.games.tools.Calculator
 import com.inspiredandroid.braincup.games.tools.Color
-import com.inspiredandroid.braincup.ui.components.CircleButton
-import com.inspiredandroid.braincup.ui.components.GameScaffold
-import com.inspiredandroid.braincup.ui.components.NumberPad
-import com.inspiredandroid.braincup.ui.components.NumberPadWithInput
-import com.inspiredandroid.braincup.ui.components.ShapeCanvas
-import com.inspiredandroid.braincup.ui.components.ShapeCanvasButton
+import com.inspiredandroid.braincup.ui.components.*
 import com.inspiredandroid.braincup.ui.localizedName
 import com.inspiredandroid.braincup.ui.theme.SuccessGreen
 import org.jetbrains.compose.resources.stringResource
@@ -84,7 +79,7 @@ private fun ColumnScope.MentalCalculationContent(
     uiState: MentalCalculationUiState,
     onAnswer: (String) -> Unit,
 ) {
-    Text(
+    MathText(
         text = uiState.calculation,
         style = MaterialTheme.typography.displaySmall,
         modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -102,10 +97,9 @@ private fun ColumnScope.ChainCalculationContent(
     uiState: ChainCalculationUiState,
     onAnswer: (String) -> Unit,
 ) {
-    Text(
+    MathText(
         text = "${uiState.calculation} = ?",
         style = MaterialTheme.typography.displaySmall,
-        textAlign = TextAlign.Center,
         modifier = Modifier
             .align(Alignment.CenterHorizontally)
             .padding(horizontal = 16.dp),
@@ -290,14 +284,32 @@ private fun ColumnScope.FractionCalculationContent(
     onAnswer: (String) -> Unit,
     onGiveUp: () -> Unit,
 ) {
-    Text(
-        text = uiState.calculation,
-        style = MaterialTheme.typography.displaySmall,
-        textAlign = TextAlign.Center,
+    Row(
         modifier = Modifier
             .align(Alignment.CenterHorizontally)
             .padding(horizontal = 16.dp),
-    )
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        val parts = uiState.calculation.split(" * ")
+        parts.forEachIndexed { index, part ->
+            val fraction = part.removeSurrounding("(", ")")
+            val fractionParts = fraction.split("/")
+            if (fractionParts.size == 2) {
+                FractionText(
+                    numerator = fractionParts[0],
+                    denominator = fractionParts[1],
+                    style = MaterialTheme.typography.displaySmall,
+                )
+            } else {
+                Text(part, style = MaterialTheme.typography.displaySmall)
+            }
+
+            if (index < parts.size - 1) {
+                Text("\u00D7", style = MaterialTheme.typography.displaySmall)
+            }
+        }
+    }
     Spacer(Modifier.height(16.dp))
     NumberPadWithInput(onInputChange = { input ->
         if (input == uiState.answerString || input.length >= 4) {
@@ -428,7 +440,17 @@ private fun ColumnScope.ValueComparisonContent(
                 .defaultMinSize(minWidth = 48.dp, minHeight = 48.dp)
                 .pointerHoverIcon(PointerIcon.Hand),
         ) {
-            Text(answer)
+            if (answer.contains("/")) {
+                val parts = answer.split("/")
+                FractionText(
+                    numerator = parts[0],
+                    denominator = parts[1],
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            } else {
+                MathText(answer)
+            }
         }
     }
 }
@@ -589,7 +611,7 @@ private fun ExpressionRow(
                             AssistChip(
                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 onClick = { onTokenClick(index) },
-                                label = { Text(token.displayValue) },
+                                label = { MathText(token.displayValue) },
                                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                             )
                         }
@@ -658,7 +680,7 @@ private fun OperatorRow(
         operators.forEach { operator ->
             CircleButton(
                 onClick = { onOperatorClick(operator) },
-                value = operator,
+                value = operator.replace("*", "\u00D7").replace("/", "\u00F7"),
             )
         }
     }


### PR DESCRIPTION
This change improves the visual representation of mathematical expressions throughout the application. It replaces standard ASCII characters ('*', '/') with professional mathematical symbols ('×', '÷') and introduces a vertical layout for fractions, replacing the previous '(2/3)' format. These improvements are applied to gameplay screens, interactive expression builders, and game previews.

---
*PR created automatically by Jules for task [17923692130235918526](https://jules.google.com/task/17923692130235918526) started by @SimonSchubert*