### PR TITLE
Improve Grid Solver Difficulty

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/app/GameUiState.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/app/GameUiState.kt
@@ -80,6 +80,7 @@ data class GridSolverUiState(
     val gridSize: Int,
     val resultsX: List<Int>,
     val resultsY: List<Int>,
+    val initialValues: List<Int?>,
 ) : GameUiState
 
 data class PatternSequenceUiState(

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/games/GridSolverGame.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/games/GridSolverGame.kt
@@ -8,6 +8,7 @@ class GridSolverGame : Game() {
     val entries = mutableListOf<MutableList<Int>>()
     val resultsX = mutableListOf<Int>()
     val resultsY = mutableListOf<Int>()
+    val initialValues = mutableListOf<Int?>()
 
     fun size(): Int = when {
         round > 7 -> 4
@@ -25,6 +26,7 @@ class GridSolverGame : Game() {
         entries.clear()
         resultsX.clear()
         resultsY.clear()
+        initialValues.clear()
 
         repeat(size()) { x ->
             entries.add(mutableListOf())
@@ -39,6 +41,19 @@ class GridSolverGame : Game() {
             repeat(size()) { y ->
                 resultsX.addOrIncrease(x, entries[y][x])
             }
+        }
+
+        val totalCells = size() * size()
+        repeat(totalCells) {
+            initialValues.add(null)
+        }
+
+        val revealCount = (size() - 1) * (size() - 1)
+        val indices = (0 until totalCells).shuffled().take(revealCount)
+        indices.forEach { index ->
+            val x = index / size()
+            val y = index % size()
+            initialValues[index] = entries[x][y]
         }
     }
 
@@ -79,5 +94,6 @@ class GridSolverGame : Game() {
         gridSize = size(),
         resultsX = resultsX.toList(),
         resultsY = resultsY.toList(),
+        initialValues = initialValues.toList(),
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/games/GridSolverGame.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/games/GridSolverGame.kt
@@ -11,9 +11,8 @@ class GridSolverGame : Game() {
     val initialValues = mutableListOf<Int?>()
 
     fun size(): Int = when {
-        round > 7 -> 4
-        round > 4 -> 3
-        else -> 2
+        round > 5 -> 4
+        else -> 3
     }
 
     private fun maxEntryValue(): Int = when {
@@ -48,7 +47,7 @@ class GridSolverGame : Game() {
             initialValues.add(null)
         }
 
-        val revealCount = (size() - 1) * (size() - 1)
+        val revealCount = if (size() == 3) 3 else 5
         val indices = (0 until totalCells).shuffled().take(revealCount)
         indices.forEach { index ->
             val x = index / size()

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
@@ -359,15 +359,15 @@ private fun GridSolverPreview() {
         verticalArrangement = Arrangement.Center,
         modifier = Modifier.padding(8.dp),
     ) {
-        // 2x2 grid + sum cards
-        val grid = remember { listOf(listOf("5", "?"), listOf("?", "?")) }
-        val rowSums = remember { listOf(8, 6) }
-        val colSums = remember { listOf(7, 7) }
+        // 3x3 grid + sum cards
+        val grid = remember { listOf(listOf("5", "?", "?"), listOf("?", "2", "?"), listOf("?", "?", "3")) }
+        val rowSums = remember { listOf(10, 12, 8) }
+        val colSums = remember { listOf(8, 11, 11) }
 
         grid.forEachIndexed { rowIndex, row ->
             Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                 row.forEachIndexed { colIndex, cell ->
-                    val isInitial = rowIndex == 0 && colIndex == 0
+                    val isInitial = (rowIndex == 0 && colIndex == 0) || (rowIndex == 1 && colIndex == 1) || (rowIndex == 2 && colIndex == 2)
                     Box(
                         modifier = Modifier
                             .size(24.dp)

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/components/GameTile.kt
@@ -360,23 +360,36 @@ private fun GridSolverPreview() {
         modifier = Modifier.padding(8.dp),
     ) {
         // 2x2 grid + sum cards
-        val grid = remember { listOf(listOf("?", "?"), listOf("?", "?")) }
+        val grid = remember { listOf(listOf("5", "?"), listOf("?", "?")) }
         val rowSums = remember { listOf(8, 6) }
         val colSums = remember { listOf(7, 7) }
 
         grid.forEachIndexed { rowIndex, row ->
             Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-                row.forEach { cell ->
+                row.forEachIndexed { colIndex, cell ->
+                    val isInitial = rowIndex == 0 && colIndex == 0
                     Box(
                         modifier = Modifier
                             .size(24.dp)
                             .background(
-                                MaterialTheme.colorScheme.surface,
+                                if (isInitial) {
+                                    MaterialTheme.colorScheme.surfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.surface
+                                },
                                 MaterialTheme.shapes.extraSmall,
                             ),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Text(text = cell, style = MaterialTheme.typography.labelSmall)
+                        Text(
+                            text = cell,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (isInitial) {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
                     }
                 }
                 Box(

--- a/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/screens/GameScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/inspiredandroid/braincup/ui/screens/GameScreen.kt
@@ -461,8 +461,16 @@ private fun ColumnScope.GridSolverContent(
     onAnswer: (String) -> Unit,
 ) {
     val totalCells = uiState.gridSize * uiState.gridSize
-    var inputs by remember { mutableStateOf(List(totalCells) { "" }) }
-    var currentIndex by remember { mutableStateOf(0) }
+    var inputs by remember {
+        mutableStateOf(
+            uiState.initialValues.map { it?.toString() ?: "" },
+        )
+    }
+    var currentIndex by remember {
+        mutableStateOf(
+            uiState.initialValues.indexOfFirst { it == null }.let { if (it == -1) 0 else it },
+        )
+    }
 
     Text(
         text = stringResource(Res.string.game_fill_grid),
@@ -482,15 +490,29 @@ private fun ColumnScope.GridSolverContent(
                     val cellIndex = rowIndex * uiState.gridSize + colIndex
                     val isCurrentCell = cellIndex == currentIndex
                     val cellValue = inputs[cellIndex]
+                    val isInitialValue = uiState.initialValues[cellIndex] != null
                     Card(
+                        onClick = {
+                            if (!isInitialValue) {
+                                currentIndex = cellIndex
+                            }
+                        },
+                        enabled = !isInitialValue,
                         modifier = Modifier
                             .padding(4.dp)
-                            .size(48.dp),
+                            .size(48.dp)
+                            .let {
+                                if (!isInitialValue) {
+                                    it.pointerHoverIcon(PointerIcon.Hand)
+                                } else {
+                                    it
+                                }
+                            },
                         colors = CardDefaults.cardColors(
-                            containerColor = if (isCurrentCell) {
-                                MaterialTheme.colorScheme.secondaryContainer
-                            } else {
-                                MaterialTheme.colorScheme.surface
+                            containerColor = when {
+                                isCurrentCell -> MaterialTheme.colorScheme.secondaryContainer
+                                isInitialValue -> MaterialTheme.colorScheme.surfaceVariant
+                                else -> MaterialTheme.colorScheme.surface
                             },
                         ),
                     ) {
@@ -501,6 +523,11 @@ private fun ColumnScope.GridSolverContent(
                             Text(
                                 text = cellValue.ifEmpty { "?" },
                                 style = MaterialTheme.typography.titleMedium,
+                                color = if (isInitialValue) {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
                             )
                         }
                     }
@@ -559,12 +586,22 @@ private fun ColumnScope.GridSolverContent(
             newInputs[currentIndex] = input.last().toString()
             inputs = newInputs
 
-            if (currentIndex < totalCells - 1) {
-                currentIndex++
-            } else {
+            // Find next empty cell index
+            var nextIndex = -1
+            for (i in 1 until totalCells) {
+                val checkIndex = (currentIndex + i) % totalCells
+                if (uiState.initialValues[checkIndex] == null) {
+                    nextIndex = checkIndex
+                    break
+                }
+            }
+
+            if (inputs.all { it.isNotEmpty() }) {
                 // All cells filled, submit answer
                 val answer = inputs.joinToString(",")
                 onAnswer(answer)
+            } else if (nextIndex != -1) {
+                currentIndex = nextIndex
             }
         }
     })

--- a/screenshotTests/src/test/kotlin/com/inspiredandroid/braincup/screenshots/ScreenshotTestData.kt
+++ b/screenshotTests/src/test/kotlin/com/inspiredandroid/braincup/screenshots/ScreenshotTestData.kt
@@ -109,14 +109,15 @@ fun createPathFinderGame(): PathFinderGame {
 fun createGridSolverGame(): GridSolverGame {
     val game = GridSolverGame()
     game.entries.clear()
-    game.entries.add(mutableListOf(3, 5))
-    game.entries.add(mutableListOf(4, 2))
+    game.entries.add(mutableListOf(3, 5, 2))
+    game.entries.add(mutableListOf(4, 2, 6))
+    game.entries.add(mutableListOf(1, 4, 3))
     game.resultsX.clear()
-    game.resultsX.addAll(listOf(7, 7))
+    game.resultsX.addAll(listOf(8, 11, 11))
     game.resultsY.clear()
-    game.resultsY.addAll(listOf(8, 6))
+    game.resultsY.addAll(listOf(10, 12, 8))
     game.initialValues.clear()
-    game.initialValues.addAll(listOf(3, null, null, null))
+    game.initialValues.addAll(listOf(3, null, null, null, 2, null, null, null, 3))
     return game
 }
 

--- a/screenshotTests/src/test/kotlin/com/inspiredandroid/braincup/screenshots/ScreenshotTestData.kt
+++ b/screenshotTests/src/test/kotlin/com/inspiredandroid/braincup/screenshots/ScreenshotTestData.kt
@@ -115,6 +115,8 @@ fun createGridSolverGame(): GridSolverGame {
     game.resultsX.addAll(listOf(7, 7))
     game.resultsY.clear()
     game.resultsY.addAll(listOf(8, 6))
+    game.initialValues.clear()
+    game.initialValues.addAll(listOf(3, null, null, null))
     return game
 }
 


### PR DESCRIPTION
The Grid Solver game was previously too easy because any low-value numbers could often satisfy the sum requirements. This change increases the challenge by pre-filling some cells with correct values, forcing the user to find the specific numbers that satisfy both row and column sums given the constraints. This makes the game more akin to a logic puzzle like KenKen or Sudoku.

---
*PR created automatically by Jules for task [15052316941039753455](https://jules.google.com/task/15052316941039753455) started by @SimonSchubert*