### PR TITLE
Lower Android minSdk to 24 (support Android 7.0)

### DIFF
--- a/androidApp/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/androidApp/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/androidApp/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/androidApp/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 appVersion = "2.21.0"
 android-versionCode = "140"
 android-compileSdk = "36"
-android-minSdk = "26"
+android-minSdk = "24"
 android-targetSdk = "36"
 kotlin = "2.4.0"
 spotless = "8.6.0"


### PR DESCRIPTION
Lower android-minSdk 26 -> 24 and add legacy launcher-icon fallbacks (mipmap-anydpi/ic_launcher{,_round}.xml) for pre-API-26 devices, which previously only had adaptive icons. App code was already API-24-safe.

Verified on an API 24 / Android 7.0 emulator: installs, launches, and the home UI plus launcher icon render correctly.

Closes Issue #17 